### PR TITLE
Readthedocs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,6 +22,18 @@ import sys
 sys.path.insert(0, os.path.abspath('../..'))
 
 
+if os.environ.get('READTHEDOCS'):
+    from unittest.mock import MagicMock
+
+    class Mock(MagicMock):
+        @classmethod
+        def __getattr__(cls, name):
+            return MagicMock()
+
+    MOCK_MODULES = ['pynput']
+    sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ if os.environ.get('READTHEDOCS'):
         def __getattr__(cls, name):
             return MagicMock()
 
-    MOCK_MODULES = ['pynput']
+    MOCK_MODULES = ['pynput', 'pynput.keyboard', 'pynput.mouse']
     sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 


### PR DESCRIPTION
Had to mock `pynput` when building documentation on readthedocs because it was mad that it didn't have an X server